### PR TITLE
Support SVGs that start with a comment

### DIFF
--- a/src/components/Svg/Svg.astro
+++ b/src/components/Svg/Svg.astro
@@ -30,7 +30,7 @@ if ("alt" in attributeOverrides) {
   throw new Error(ALT_NOT_ALLOWED);
 }
 
-if (!svgSource.trimStart().toLowerCase().startsWith("<svg")) {
+if (!svgSource.trimStart().toLowerCase().replaceAll(/<!--.*?-->/gs, "").startsWith("<svg")) {
   throw new Error(`${SVG_NOT_FOUND}, provided: ${svgSource.slice(0, 23)}
   maybe you need to add '?raw' to the end of the import?`);
 }

--- a/src/components/Svg/overrideSvgAttributes.test.ts
+++ b/src/components/Svg/overrideSvgAttributes.test.ts
@@ -103,6 +103,10 @@ describe("overrideSvgAtrributes", () => {
     );
   });
 
+  it("should accept and `svgSource` which starts with a comment `<!---`", async () => {
+    expect(await overrideSvgAttributes("<!-- some comment --><svg></svg>")).toBe('<svg></svg>')
+  });
+
   it("should add properties successfully", async () => {
     expect(
       await overrideSvgAttributes("<SVG></SVG>", {

--- a/src/components/Svg/overrideSvgAttributes.ts
+++ b/src/components/Svg/overrideSvgAttributes.ts
@@ -13,7 +13,8 @@ export async function overrideSvgAttributes(
   if (!svgSource) {
     throw new Error(EMPTY_STRING_ERR);
   }
-  if (!svgSource.trimStart().toLowerCase().startsWith("<svg")) {
+
+  if (!svgSource.trimStart().toLowerCase().replace(/<!--.*?-->/gs, "").startsWith("<svg")) {
     throw new Error(MUST_START_WITH_SVG);
   }
 


### PR DESCRIPTION
Currently this breaks on Svg's that start with a comment, I noticed this being a problem when importing Svgs from a icon library.

This implementation strips the comments before checking and overriding the attributes. Tests added.