### PR TITLE
Require min package release of 3 days

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,4 +12,7 @@
       matchPackageNames: ["prettier"],
     },
   ],
+  npm: {
+    minimumReleaseAge: "3 days"
+  }
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,6 +13,6 @@
     },
   ],
   npm: {
-    minimumReleaseAge: "3 days"
-  }
+    minimumReleaseAge: "3 days",
+  },
 }


### PR DESCRIPTION
Updates .github/renovate.json5 to require updates to have been out for 3 days

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update policy: npm package updates will only be considered after the package has been available for at least 3 days.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->